### PR TITLE
Support SiFive specific cache control instructions in binutils-2.32

### DIFF
--- a/gas/testsuite/gas/riscv/cache-control.d
+++ b/gas/testsuite/gas/riscv/cache-control.d
@@ -1,0 +1,15 @@
+#as: -march=rv32i
+#objdump: -dr
+
+.*:[ 	]+file format .*
+
+
+Disassembly of section .text:
+
+0+000 <.text>:
+[ 	]+0:[ 	]+fc050073[ 	]+cflush.d.l1[ 	]+a0
+[ 	]+4:[ 	]+fc250073[ 	]+cdiscard.d.l1[ 	]+a0
+[ 	]+8:[ 	]+fc100073[ 	]+cflush.i.l1
+[ 	]+c:[ 	]+fc050073[ 	]+cflush.d.l1[ 	]+a0
+[ 	]+10:[ 	]+fc250073[ 	]+cdiscard.d.l1[ 	]+a0
+[ 	]+14:[ 	]+fc100073[ 	]+cflush.i.l1

--- a/gas/testsuite/gas/riscv/cache-control.s
+++ b/gas/testsuite/gas/riscv/cache-control.s
@@ -1,0 +1,7 @@
+	.insn i 0x73, 0, x0, x10, -0x40
+	.insn i 0x73, 0, x0, x10, -0x3E
+	.insn i 0x73, 0, x0, x0,  -0x3F
+
+	cflush.d.l1   x10
+	cdiscard.d.l1 x10
+	cflush.i.l1

--- a/include/opcode/riscv-opc.h
+++ b/include/opcode/riscv-opc.h
@@ -575,6 +575,13 @@
 #define MASK_CUSTOM3_RD_RS1  0x707f
 #define MATCH_CUSTOM3_RD_RS1_RS2 0x707b
 #define MASK_CUSTOM3_RD_RS1_RS2  0x707f
+/* SiFive specific cache control instruction.  */
+#define MATCH_CFLUSH_D_L1   0xfc000073
+#define MASK_CFLUSH_D_L1    0xfff07fff
+#define MATCH_CDISCARD_D_L1 0xfc200073
+#define MASK_CDISCARD_D_L1  0xfff07fff
+#define MATCH_CFLUSH_I_L1   0xfc100073
+#define MASK_CFLUSH_I_L1    0xffffffff
 
 /* These registers are in priv spec 1.10.  */
 #define CSR_USTATUS 0x0
@@ -1123,6 +1130,9 @@ DECLARE_INSN(custom3_rs1_rs2, MATCH_CUSTOM3_RS1_RS2, MASK_CUSTOM3_RS1_RS2)
 DECLARE_INSN(custom3_rd, MATCH_CUSTOM3_RD, MASK_CUSTOM3_RD)
 DECLARE_INSN(custom3_rd_rs1, MATCH_CUSTOM3_RD_RS1, MASK_CUSTOM3_RD_RS1)
 DECLARE_INSN(custom3_rd_rs1_rs2, MATCH_CUSTOM3_RD_RS1_RS2, MASK_CUSTOM3_RD_RS1_RS2)
+DECLARE_INSN(cflush_d_l1, MATCH_CFLUSH_D_L1, MASK_CFLUSH_D_L1)
+DECLARE_INSN(cdiscard_d_l1, MATCH_CDISCARD_D_L1, MASK_CDISCARD_D_L1)
+DECLARE_INSN(cflush_i_l1, MATCH_CFLUSH_I_L1, MASK_CFLUSH_I_L1)
 #endif
 #ifdef DECLARE_CSR
 /* These registers are in priv spec 1.10.  */

--- a/opcodes/riscv-opc.c
+++ b/opcodes/riscv-opc.c
@@ -778,6 +778,11 @@ const struct riscv_opcode riscv_opcodes[] =
 {"sfence.vma", 0, {"I", 0},   "s,t",  MATCH_SFENCE_VMA, MASK_SFENCE_VMA, match_opcode, 0 },
 {"wfi",        0, {"I", 0},   "",     MATCH_WFI, MASK_WFI, match_opcode, 0 },
 
+/* SiFive specific cache control instruction.  */
+{"cflush.d.l1",   0, {"I", 0},   "s",  MATCH_CFLUSH_D_L1, MASK_CFLUSH_D_L1, match_opcode, 0 },
+{"cdiscard.d.l1", 0, {"I", 0},   "s",  MATCH_CDISCARD_D_L1, MASK_CDISCARD_D_L1, match_opcode, 0 },
+{"cflush.i.l1",   0, {"I", 0},   "",   MATCH_CFLUSH_I_L1, MASK_CFLUSH_I_L1, match_opcode, 0 },
+
 /* Terminate the list.  */
 {0, 0, {0}, 0, 0, 0, 0, 0}
 };


### PR DESCRIPTION
According to the following links,
1. https://github.com/sifive/freedom-metal/blob/v201908-branch/src/cache.c
2. https://sifive.cdn.prismic.io/sifive/6d9a2510-2632-44f3-adb9-d0430f139372_sifive_coreip_U74MC_AXI4_rtl_v19_08p2p0_release_manual.pdf
3. https://github.com/sifive/sw-fs-freedomstudio/blob/master/com.sifive.freedomstudio/bundles/com.sifive.freedomstudio.toolchain/src/com/sifive/freedomstudio/toolchain/support/InstructionMapper.java

There are three cache control instructions,
1. CFLUSH.D.L1   RS1
2. CDISCARD.D.L1 RS1
3. CFLUSH.I.L1

These instructions use the same funct3 0x0 [14:12].  CFLUSH.D.L1 use 0xfc000073
opcode (0xfc0 [31:20] + 0x0 [11:7] + SYSTEM OP [6:2] + 0x3 [1:0]) with optional
rs1.  CDISCARD.D.L1 use 0xfc200073 opcode (0xfc2 [31:20], ...) with optional
rs1.  CFLUSH.I.L1 use 0xfc100073 opcode.