### PR TITLE
GDB overlay support for RISC-V

### DIFF
--- a/gdb/riscv-tdep.c
+++ b/gdb/riscv-tdep.c
@@ -3638,6 +3638,9 @@ riscv_gdbarch_init (struct gdbarch_info info,
 
   register_riscv_ravenscar_ops (gdbarch);
 
+  /* Support simple overlay manager.  */
+  set_gdbarch_overlay_update (gdbarch, simple_overlay_update);
+
   return gdbarch;
 }
 

--- a/gdb/symfile.c
+++ b/gdb/symfile.c
@@ -3294,7 +3294,7 @@ overlay_auto_command (const char *args, int from_tty)
   overlay_debugging = ovly_auto;
   enable_overlay_breakpoints ();
   if (info_verbose)
-    printf_unfiltered (_("Automatic overlay debugging enabled."));
+    printf_unfiltered (_("Automatic overlay debugging enabled.\n"));
 }
 
 /* Function: overlay_manual_command
@@ -3307,7 +3307,7 @@ overlay_manual_command (const char *args, int from_tty)
   overlay_debugging = ovly_on;
   disable_overlay_breakpoints ();
   if (info_verbose)
-    printf_unfiltered (_("Overlay debugging enabled."));
+    printf_unfiltered (_("Overlay debugging enabled.\n"));
 }
 
 /* Function: overlay_off_command
@@ -3320,7 +3320,7 @@ overlay_off_command (const char *args, int from_tty)
   overlay_debugging = ovly_off;
   disable_overlay_breakpoints ();
   if (info_verbose)
-    printf_unfiltered (_("Overlay debugging disabled."));
+    printf_unfiltered (_("Overlay debugging disabled.\n"));
 }
 
 static void


### PR DESCRIPTION
1. **Fixed problem with overlay support for RISC-V**
Now GDB-client supports overlay debugging in auto-mode.

To able GDB support overlay debugging it is necessary to initialize pointer `gdbarch->overlay_update` with function pointer `simple_overlay_update(struct obj_section *osect)`: In file `/gdb/riscv-tdep.c` at the end of definition of `riscv_gdbarch_init(...)` should be called `set_gdbarch_overlay_update(gdbarch, simple_overlay_update)` - similarly with file `/gdb/m32r-tdep.c`.

Without this fix GDB-client can't update overlay table `_ovly_table` from target RAM and overlay debugging doesn't work:

    (gdb) overlay list
    No sections are mapped.
    (gdb) overlay load
    This target does not know how to read its overlay state.

With this fix GDB-client is able to support overlay debugging in auto-mode (GDB-client updates overlay table `_ovly_table` from target RAM):

    (gdb) set verbose on
    (gdb) overlay auto
    Automatic overlay debugging enabled.
    ...
    (gdb) overlay list
    Section .ovly1, loaded at 0x10080444 - 0x100805d0, mapped at 0x10000060 - 0x100001ec

2. **Fixed problem with output of overlay GDB-commands**

GDB-commands `overlay auto`, `overlay manual`, `overlay off` have incorrect output message. In file `/gdb/symfile.c` in functions `overlay_auto_command(...)`, `overlay_manual_command(...)`, `overlay_off_command(...)` in call `printf_filtered(_("..."))` it is necessary to add '\n' at the end of string. Otherwise output message of this GDB-commands unseparated with next GDB-command output message. This messages are displayed only with `set verbose on`.

Without this fix. Incorrect (unseparated):

    (gdb) set verbose on
    (gdb) overlay auto
    <nothing>
    (gdb) overlay list
    Automatic overlay debugging enabled.No sections are mapped.

With this fix (added '\n'). Correct:

    (gdb) set verbose on
    (gdb) overlay auto
    Automatic overlay debugging enabled.
    (gdb) overlay list
    No sections are mapped.

- - - -

My overlay demo project for RISC-V: [dmi391/overlay_demo](https://github.com/dmi391/overlay_demo)
My custom build of GDB-client with this two fixes (it works correct): [release gdb-riscv-ovly](https://github.com/dmi391/riscv-binutils-gdb/releases/tag/gdb-riscv-ovly_v1.0.0)
